### PR TITLE
Use connection row of the table for each node

### DIFF
--- a/yoin-core/src/dic/matrix.rs
+++ b/yoin-core/src/dic/matrix.rs
@@ -35,8 +35,10 @@ impl<T: AsRef<[i16]>> Matrix<T> {
         self.encode::<W, NativeEndian>(w)
     }
 
-    pub fn connection_cost(&self, right_id: u16, left_id: u16) -> i16 {
-        self[(right_id, left_id)]
+    pub fn row(&self, left_id: u16) -> &[i16] {
+        let h = left_id as usize;
+        let start = h * self.width  as usize;
+        &self.table.as_ref()[start..start + self.width as usize]
     }
 }
 

--- a/yoin-core/src/tokenizer/lattice.rs
+++ b/yoin-core/src/tokenizer/lattice.rs
@@ -129,8 +129,8 @@ impl<'a, D: Dic<'a> + 'a, Unk: UnknownDic + 'a, T: AsRef<[i16]>> Lattice<'a, D, 
             kind: kind,
         });
         let node = self.arena.get(id);
-        self.prev_table.push(DUMMY_PREV_NODE);
-        self.cost_table.push(MAX_COST);
+        let mut node_prev = DUMMY_PREV_NODE;
+        let mut node_cost = MAX_COST;
 
         for &enode_id in &self.end_nodes[self.pointer] {
             let enode = self.arena.get(enode_id);
@@ -138,11 +138,14 @@ impl<'a, D: Dic<'a> + 'a, Unk: UnknownDic + 'a, T: AsRef<[i16]>> Lattice<'a, D, 
                 self.matrix.connection_cost(enode.kind.right_id(), node.kind.left_id()) as i64 +
                 node.kind.weight() as i64;
             let total_cost = self.cost_table[enode_id] + cost;
-            if total_cost < self.cost_table[id] {
-                self.cost_table[id] = total_cost;
-                self.prev_table[id] = enode_id;
+            if total_cost < node_cost {
+                node_cost = total_cost;
+                node_prev = enode_id;
             }
         }
+
+        self.prev_table.push(node_prev);
+        self.cost_table.push(node_cost);
         self.end_nodes[self.pointer + node.surface_len()].push(id);
     }
 

--- a/yoin-core/src/tokenizer/lattice.rs
+++ b/yoin-core/src/tokenizer/lattice.rs
@@ -129,14 +129,14 @@ impl<'a, D: Dic<'a> + 'a, Unk: UnknownDic + 'a, T: AsRef<[i16]>> Lattice<'a, D, 
             kind: kind,
         });
         let node = self.arena.get(id);
+        let node_weight = node.kind.weight() as i64;
+        let node_conn_row = self.matrix.row(node.kind.left_id());
         let mut node_prev = DUMMY_PREV_NODE;
         let mut node_cost = MAX_COST;
 
         for &enode_id in &self.end_nodes[self.pointer] {
             let enode = self.arena.get(enode_id);
-            let cost =
-                self.matrix.connection_cost(enode.kind.right_id(), node.kind.left_id()) as i64 +
-                node.kind.weight() as i64;
+            let cost = node_conn_row[enode.kind.right_id() as usize] as i64 + node_weight;
             let total_cost = self.cost_table[enode_id] + cost;
             if total_cost < node_cost {
                 node_cost = total_cost;
@@ -274,7 +274,10 @@ impl<'a, D: Dic<'a> + 'a, Unk: UnknownDic + 'a, T: AsRef<[i16]>> Lattice<'a, D, 
         writeln!(w, "\tnode [shape=circle]")?;
         for (id, &prev_id) in self.prev_table.iter().enumerate() {
             if prev_id != DUMMY_PREV_NODE {
-                writeln!(w, "\t\"{}\"[label=\"{}\"];", id, self.arena.get(id).surface())?;
+                writeln!(w,
+                         "\t\"{}\"[label=\"{}\"];",
+                         id,
+                         self.arena.get(id).surface())?;
                 let prev_node = self.arena.get(prev_id);
                 writeln!(w, "\t\"{}\"[label=\"{}\"];", prev_id, prev_node.surface())?;
                 writeln!(w, "\t\"{}\" -> \"{}\";", prev_id, id)?;


### PR DESCRIPTION
lattice の構築時に，今注目している node との連結コストを何度も lookup してくる必要がある。
そこで、今注目している node の行をテーブルから前もって持ってきておいて，もう一方の node の id だけでコストを計算できるようにする．